### PR TITLE
Fix Netlify's focal build image warning

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,11 @@
 [build]
   command = "npm run build"
   publish = "dist"
-  functions = "./netlify/functions/"  
+  functions = "./netlify/functions/"
+  
+[build.environment]
+  NODE_VERSION = "18"
+  NETLIFY_USE_BUILDKIT = "true"  
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
# Changes Made

1. Added Node.js version specification: Set `NODE_VERSION = "18"` to ensure you're using a modern Node.js version
2. Enabled Buildkit: Added `NETLIFY_USE_BUILDKIT = "true"` which tells Netlify to use the newer build system instead of the deprecated Focal image

# What this fixes
The Focal build image deprecation warning occurs because Netlify is phasing out the Ubuntu Focal (20.04) build environment in favour of newer build systems. By adding `NETLIFY_USE_BUILDKIT = "true"`, we're opting into Netlify's newer build infrastructure that doesn't rely on the deprecated Focal image.